### PR TITLE
ZX-Uno version back to life and no need to use .esprst and .iwinit

### DIFF
--- a/src/include/uno/zifi.h
+++ b/src/include/uno/zifi.h
@@ -22,6 +22,7 @@
 #define FMODE_CREATE 0x0E
 
 extern char* ssid;
+extern char* pass;
 extern char is_connected;
 
 void initWifi();

--- a/src/spectrum/main.c
+++ b/src/spectrum/main.c
@@ -51,8 +51,11 @@ void main(void)
   connect();
 #endif
   io_init();
+
+#ifndef NO_BIT
   bit_play("2A--");  //Ready beep
-  
+#endif
+
   for (;;)
     {
       keyboard_main();


### PR DESCRIPTION
After refactoring zx-uno version goes broken.

I've fixed it. And made it possible use as is without external tools like .esprst and .iwconfig.

If you haven't stored WiFi config - it ask you on start. 
It means that tool can be published on site and used without any dependencies. 

BTW, I've removed unused 2k buffer - more free space for plato :-) 