### PR TITLE
Performance tuning

### DIFF
--- a/Makefile.zx-rs232-IF1
+++ b/Makefile.zx-rs232-IF1
@@ -10,7 +10,7 @@ OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
 CFLAGS=+zx -D__SPECTRUM__ -D__SPECTRUM_RS232__
-LDFLAGS=-lndos -lm -lrs232if1 -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr #normal tap - Product TAP
+LDFLAGS=-O2 -lndos -lm -lrs232if1 -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr #normal tap - Product TAP
 #LDFLAGS=-lndos -lm -lrs232if1 -create-app -subtype=turbo -audio #TURBO WAV only - DEV compiler
 
 INC_DIRS := $(shell find $(SRC_DIRS) -type d)

--- a/Makefile.zx-rs232-P3
+++ b/Makefile.zx-rs232-P3
@@ -12,7 +12,7 @@ DEPS := $(OBJS:.o=.d)
 CFLAGS=+zx -D__SPECTRUM__ -D__SPECTRUM_RS232__
 #LDFLAGS=-O2 -lndos -lm -lrs232plus -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr #normal tap - Product TAP
 LDFLAGS=-O2 -lndos -lm -lrs232plus -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr -subtype=plus3 #Plus 3 disk - Product DSK
-#LDFLAGS=-lndos -lm -lrs232plus -create-app -subtype=turbo -audio #TURBO WAV only - DEV compiler
+#LDFLAGS=-O2 -lndos -lm -lrs232plus -create-app -subtype=turbo -audio #TURBO WAV only - DEV compiler
 
 INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))

--- a/Makefile.zx-rs232-P3
+++ b/Makefile.zx-rs232-P3
@@ -1,6 +1,6 @@
-TARGET_EXEC ?= platoSNET.bin
+TARGET_EXEC ?= platoP3.bin
 
-BUILD_DIR ?= ./build-SNET
+BUILD_DIR ?= ./build-P3
 SRC_DIRS ?= ./src
 
 CC=zcc
@@ -9,10 +9,10 @@ SRCS := $(shell find $(SRC_DIRS) -name *.cpp -or -name *.c -or -name *.s)
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
-CFLAGS=+zx -D__SPECTRUM__ -D__SPECTRANET__ -Iinclude -I../include -I../../include
-LDFLAGS=-O2 -lndos -llibsocket -lm -create-app 
-
-
+CFLAGS=+zx -D__SPECTRUM__ -D__SPECTRUM_RS232__
+#LDFLAGS=-O2 -lndos -lm -lrs232plus -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr #normal tap - Product TAP
+LDFLAGS=-O2 -lndos -lm -lrs232plus -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr -subtype=plus3 #Plus 3 disk - Product DSK
+#LDFLAGS=-lndos -lm -lrs232plus -create-app -subtype=turbo -audio #TURBO WAV only - DEV compiler
 
 INC_DIRS := $(shell find $(SRC_DIRS) -type d)
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))

--- a/Makefile.zx-rs232-PLUS
+++ b/Makefile.zx-rs232-PLUS
@@ -10,7 +10,8 @@ OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 DEPS := $(OBJS:.o=.d)
 
 CFLAGS=+zx -D__SPECTRUM__ -D__SPECTRUM_RS232__
-LDFLAGS=-lndos -lm -lrs232plus -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr #normal tap - Product TAP
+LDFLAGS=-O2 -lndos -lm -lrs232plus -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr #normal tap - Product TAP
+#LDFLAGS=-O2 -lndos -lm -lrs232plus -create-app -Cz--screen -Czsrc/spectrum/rs232/ptzx-loading-splash-1.scr -subtype=plus3 #Plus 3 disk - Product DSK
 #LDFLAGS=-lndos -lm -lrs232plus -create-app -subtype=turbo -audio #TURBO WAV only - DEV compiler
 
 INC_DIRS := $(shell find $(SRC_DIRS) -type d)

--- a/Makefile.zx-spectranet
+++ b/Makefile.zx-spectranet
@@ -11,6 +11,7 @@ DEPS := $(OBJS:.o=.d)
 
 CFLAGS=+zx -D__SPECTRUM__ -D__SPECTRANET__ -Iinclude -I../include -I../../include
 LDFLAGS=-O2 -lndos -llibsocket -lm -create-app 
+#LDFLAGS=-O2 -lndos -llibsocket -lm -create-app -subtype=turbo -audio #TURBO WAV only - DEV compiler
 
 
 

--- a/src/common/protocol.c
+++ b/src/common/protocol.c
@@ -785,201 +785,205 @@ void
 ShowPLATO (padByte *buff, unsigned short count)
 {
   while (count--)
+  {
+    theChar = *buff++;
+    if (lastChar==0xFF && theChar==0xFF)
     {
-      theChar = *buff++;
-      if (lastChar==0xFF && theChar==0xFF)
-	{
-	  // Drop this character, it is an escaped TELNET IAC.
-	  lastChar=0;
-	}
+      // Drop this character, it is an escaped TELNET IAC.
+      lastChar=0;
+    }
+    else
+    {
+      rawChar=theChar;
+      theChar &=0x7F;
+      if (TTY)
+      {
+          if (!EscFlag)
+            screen_tty_char (theChar);
+          else if (theChar == 0x02)
+            InitPLATOx ();
+      }
+      else if (EscFlag)
+      {
+        switch (theChar)
+        {
+          case 0x03:
+            InitTTY ();
+            break;
+            
+          case 0x0C:
+            screen_clear ();
+            break;
+            
+          case 0x11:
+            CurMode = ModeInverse;
+            SetFast();
+            break;
+          case 0x12:
+            CurMode = ModeWrite;
+            SetFast();
+            break;
+          case 0x13:
+            CurMode = ModeErase;
+            SetFast();
+            break;
+          case 0x14:
+            CurMode = ModeRewrite;
+            SetFast();
+            break;
+            
+          case 0x32:
+            SetCommand (mLoadCoord, tCoord);
+            break;
+            
+          case 0x40:
+            Superx ();
+            break;
+          case 0x41:
+            Subx ();
+            break;
+            
+          case 0x42:
+            CurMem = M0;
+            break;
+          case 0x43:
+            CurMem = M1;
+            break;
+          case 0x44:
+            CurMem = M2;
+            break;
+          case 0x45:
+            CurMem = M3;
+            break;
+            
+          case 0x4A:
+            Rotate = false;
+            SetFast();
+            break;
+          case 0x4B:
+            Rotate = true;
+            SetFast();
+            break;
+          case 0x4C:
+            Reverse = false;
+            SetFast();
+            break;
+          case 0x4D:
+            Reverse = true;
+            SetFast();
+            break;
+          case 0x4E:
+            ModeBold = false;
+            SetFast();
+            break;
+          case 0x4F:
+            ModeBold = true;
+            SetFast();
+            break;
+            
+          case 0x50:
+            SetMode (mLoadChar, tWord);
+            break;
+          case 0x51:
+            SetCommand (mSSF, tWord);
+            break;
+          case 0x52:
+            SetCommand (mExternal, tWord);
+            break;
+          case 0x53:
+            SetMode (mLoadMem, tWord);
+            break;
+          case 0x54:
+            SetMode (mMode5, tWord);
+            break;
+          case 0x55:
+            SetMode (mMode6, tWord);
+            break;
+          case 0x56:
+            SetMode (mMode7, tWord);
+            break;
+          case 0x57:
+            SetCommand (mLoadAddr, tWord);
+            break;
+          case 0x59:
+            SetCommand (mLoadEcho, tWord);
+            break;
+            
+          case 0x5A:
+            Marginx ();
+            break;
+            
+          case 0x61:
+            SetCommand (mFore, tColor);
+            break;
+          case 0x62:
+            SetCommand (mBack, tColor);
+            break;
+          case 0x63:
+            SetCommand (mPaint, tPaint);
+            break;
+        }
+      }
+      else if (theChar < 0x20)
+      {
+        if (charCount > 0)
+        {
+          screen_char_draw (&charCoord, charBuff, charCount);
+          charCount = 0;
+        }
+
+        switch (theChar)
+        {
+          case 0x00:
+            screen_wait();
+          case 0x08:
+            BSx ();
+            break;
+          case 0x09:
+            HTx ();
+            break;
+          case 0x0A:
+            LFx ();
+            break;
+          case 0x0B:
+            VTx ();
+            break;
+          case 0x0C:
+            FFx ();
+            break;
+          case 0x0D:
+            CRx ();
+            break;
+            
+          case 0x19:
+            SetMode (mBlock, tCoord);
+            break;
+          case 0x1C:
+            SetMode (mPoint, tCoord);
+            break;
+          case 0x1D:
+            SetMode (mLine, tCoord);
+            break;
+          case 0x1F:
+            SetMode (mAlpha, tByte);
+            break;
+        }
+      }
       else
-	{
-	  rawChar=theChar;
-	  theChar &=0x7F;
-	  if (TTY)
-	    {
-	      if (!EscFlag)
-		screen_tty_char (theChar);
-	      else if (theChar == 0x02)
-		InitPLATOx ();
-	    }
-	  else if (EscFlag)
-	    {
-	      switch (theChar)
-		{
-		case 0x03:
-		  InitTTY ();
-		  break;
-		  
-		case 0x0C:
-		  screen_clear ();
-		  break;
-		  
-		case 0x11:
-		  CurMode = ModeInverse;
-		  SetFast();
-		  break;
-		case 0x12:
-		  CurMode = ModeWrite;
-		  SetFast();
-		  break;
-		case 0x13:
-		  CurMode = ModeErase;
-		  SetFast();
-		  break;
-		case 0x14:
-		  CurMode = ModeRewrite;
-		  SetFast();
-		  break;
-		  
-		case 0x32:
-		  SetCommand (mLoadCoord, tCoord);
-		  break;
-		  
-		case 0x40:
-		  Superx ();
-		  break;
-		case 0x41:
-		  Subx ();
-		  break;
-		  
-		case 0x42:
-		  CurMem = M0;
-		  break;
-		case 0x43:
-		  CurMem = M1;
-		  break;
-		case 0x44:
-		  CurMem = M2;
-		  break;
-		case 0x45:
-		  CurMem = M3;
-		  break;
-		  
-		case 0x4A:
-		  Rotate = false;
-		  SetFast();
-		  break;
-		case 0x4B:
-		  Rotate = true;
-		  SetFast();
-		  break;
-		case 0x4C:
-		  Reverse = false;
-		  SetFast();
-		  break;
-		case 0x4D:
-		  Reverse = true;
-		  SetFast();
-		  break;
-		case 0x4E:
-		  ModeBold = false;
-		  SetFast();
-		  break;
-		case 0x4F:
-		  ModeBold = true;
-		  SetFast();
-		  break;
-		  
-		case 0x50:
-		  SetMode (mLoadChar, tWord);
-		  break;
-		case 0x51:
-		  SetCommand (mSSF, tWord);
-		  break;
-		case 0x52:
-		  SetCommand (mExternal, tWord);
-		  break;
-		case 0x53:
-		  SetMode (mLoadMem, tWord);
-		  break;
-		case 0x54:
-		  SetMode (mMode5, tWord);
-		  break;
-		case 0x55:
-		  SetMode (mMode6, tWord);
-		  break;
-		case 0x56:
-		  SetMode (mMode7, tWord);
-		  break;
-		case 0x57:
-		  SetCommand (mLoadAddr, tWord);
-		  break;
-		case 0x59:
-		  SetCommand (mLoadEcho, tWord);
-		  break;
-		  
-		case 0x5A:
-		  Marginx ();
-		  break;
-		  
-		case 0x61:
-		  SetCommand (mFore, tColor);
-		  break;
-		case 0x62:
-		  SetCommand (mBack, tColor);
-		  break;
-		case 0x63:
-		  SetCommand (mPaint, tPaint);
-		  break;
-		}
-	    }
-	  else if (theChar < 0x20)
-	    {
-	      if (charCount > 0)
-		{
-		  screen_char_draw (&charCoord, charBuff, charCount);
-		  charCount = 0;
-		}
-	      switch (theChar)
-		{
-		case 0x00:
-		  screen_wait();
-		case 0x08:
-		  BSx ();
-		  break;
-		case 0x09:
-		  HTx ();
-		  break;
-		case 0x0A:
-		  LFx ();
-		  break;
-		case 0x0B:
-		  VTx ();
-		  break;
-		case 0x0C:
-		  FFx ();
-		  break;
-		case 0x0D:
-		  CRx ();
-		  break;
-		  
-		case 0x19:
-		  SetMode (mBlock, tCoord);
-		  break;
-		case 0x1C:
-		  SetMode (mPoint, tCoord);
-		  break;
-		case 0x1D:
-		  SetMode (mLine, tCoord);
-		  break;
-		case 0x1F:
-		  SetMode (mAlpha, tByte);
-		  break;
-		}
-	    }
-	  else
-	    DataChar ();
-	  
-	  EscFlag = (theChar == 0x1B);
-	  lastChar=rawChar;
-	}
+        DataChar ();
+  
+      EscFlag = (theChar == 0x1B);
+      lastChar=rawChar;
     }
+    // CHECK THE KEYBOARD WHILE PROCESSING THE BUFFER
+    keyboard_main();
+  }
+  
   if (charCount > 0)
-    {
-      screen_char_draw (&charCoord, charBuff, charCount);
-      charCount = 0;
-    }
+  {
+    screen_char_draw (&charCoord, charBuff, charCount);
+    charCount = 0;
+  }
 }
 
 /**

--- a/src/common/protocol.c
+++ b/src/common/protocol.c
@@ -975,8 +975,10 @@ ShowPLATO (padByte *buff, unsigned short count)
       EscFlag = (theChar == 0x1B);
       lastChar=rawChar;
     }
-    // CHECK THE KEYBOARD WHILE PROCESSING THE BUFFER
-    keyboard_main();
+    
+    #ifdef __SPECTRUM__
+    keyboard_main();  // Spectrum additional keyboard checks when processing rxbuffer
+    #endif
   }
   
   if (charCount > 0)

--- a/src/include/io.h
+++ b/src/include/io.h
@@ -13,6 +13,8 @@
 #define XON  0x11
 #define XOFF 0x13
 
+extern char rxdata[1024];
+
 /**
  * io_init() - Set-up the I/O
  */

--- a/src/include/io.h
+++ b/src/include/io.h
@@ -13,8 +13,6 @@
 #define XON  0x11
 #define XOFF 0x13
 
-extern char rxdata[1024];
-
 /**
  * io_init() - Set-up the I/O
  */

--- a/src/spectrum/keyboard.c
+++ b/src/spectrum/keyboard.c
@@ -24,8 +24,6 @@
 extern padBool TTY;
 static unsigned char ch;
 unsigned char is_extend=0;  //deleted static is used in IO.C now for Rasta bars
-static int loopKeyScan;    // Used to loop the keyboard scanning
-
 
 /**
  * A simple key press feedback.
@@ -82,24 +80,7 @@ void keyboard_out_tty(char ch)
  */
 void keyboard_main(void)
 {
-  if(strlen(rxdata) > 50)
-  {
-    loopKeyScan = 0;
-  }
-  else if(strlen(rxdata) > 0)
-  {
-    loopKeyScan = 10;
-  }
-  else
-  {
-    loopKeyScan = 20;
-  }
-  
-  do
-  {
-    ch=getk();
-  } while (--loopKeyScan > 0 && ch==0x00);
-
+  ch=getk();
   if (ch!=0x00)
     {
       keyboard_click(); // maybe something better? ;) -thom

--- a/src/spectrum/keyboard.c
+++ b/src/spectrum/keyboard.c
@@ -24,6 +24,8 @@
 extern padBool TTY;
 static unsigned char ch;
 unsigned char is_extend=0;  //deleted static is used in IO.C now for Rasta bars
+static int loopKeyScan;    // Used to loop the keyboard scanning
+
 
 /**
  * A simple key press feedback.
@@ -80,45 +82,63 @@ void keyboard_out_tty(char ch)
  */
 void keyboard_main(void)
 {
-  ch=getk();	
+  if(strlen(rxdata) > 50)
+  {
+    loopKeyScan = 0;
+  }
+  else if(strlen(rxdata) > 0)
+  {
+    loopKeyScan = 10;
+  }
+  else
+  {
+    loopKeyScan = 20;
+  }
+  
+  do
+  {
+    ch=getk();
+  } while (--loopKeyScan > 0 && ch==0x00);
+
   if (ch!=0x00)
     {
       keyboard_click(); // maybe something better? ;) -thom
       if (is_extend==0 && ch==0x0e) // EXTEND pressed.
-	{
-	  zx_border(INK_GREEN);
-	  is_extend=1;
-	}
+      {
+        zx_border(INK_GREEN);
+        is_extend=1;
+      }
       else if (TTY)
-	{
-	  keyboard_out_tty(ch);	// *IRQ-OFF  (SENDING DATA)
-	}
+      {
+        keyboard_out_tty(ch);	// *IRQ-OFF  (SENDING DATA)
+      }
       else if (is_extend==1 && ch==0x30)
-	{
-	  is_extend=0;
-	  help_run();
-	}
+      {
+        is_extend=0;
+        help_run();
+      }
       else if (is_extend==1 && ch==0x39)
-	{
-	  zx_border(INK_MAGENTA);
-	  zx_hardcopy();
-	  zx_border(INK_BLACK);
-	  is_extend=0;
-	}
+      {
+        zx_border(INK_MAGENTA);
+        zx_hardcopy();
+        zx_border(INK_BLACK);
+        is_extend=0;
+      }
       else if (is_extend==1)
-	{
-	  zx_border(INK_GREEN);
-	  keyboard_out(extend_key_to_pkey[ch]);
-	  is_extend=0;
-	  zx_border(INK_BLACK);
-	}
+      {
+        zx_border(INK_GREEN);
+        keyboard_out(extend_key_to_pkey[ch]);
+        is_extend=0;
+        zx_border(INK_BLACK);
+      }
       else
-	{
-	  zx_border(INK_BLACK);
-	  keyboard_out(key_to_pkey[ch]);
-	}
+      {
+        zx_border(INK_BLACK);
+        keyboard_out(key_to_pkey[ch]);
+      }
     }
-  //  ELSE here for No Keypress events
+    ch=0x00;  // be clean and clear it
+    //  ELSE here for No Keypress events
 }
 
 #endif /* __SPECTRUM__ */

--- a/src/spectrum/keyboard.c
+++ b/src/spectrum/keyboard.c
@@ -81,7 +81,9 @@ void keyboard_out_tty(char ch)
 void keyboard_main(void)
 {
   ch=getk();
-  if (ch!=0x00)
+  do
+  {
+    if (ch!=0x00)
     {
       keyboard_click(); // maybe something better? ;) -thom
       if (is_extend==0 && ch==0x0e) // EXTEND pressed.
@@ -119,7 +121,9 @@ void keyboard_main(void)
       }
     }
     ch=0x00;  // be clean and clear it
-    //  ELSE here for No Keypress events
+      //  ELSE here for No Keypress events
+    ch=getk();
+  } while (ch!=0x00);
 }
 
 #endif /* __SPECTRUM__ */

--- a/src/spectrum/main.c
+++ b/src/spectrum/main.c
@@ -55,10 +55,7 @@ void main(void)
   
   for (;;)
     {
-      for(int Kscan=0;Kscan<20;Kscan++)  //Keyboard scanning loop		
-      {
-	      keyboard_main();
-      }
+	    keyboard_main();
       io_main();
     }
 }

--- a/src/spectrum/main.c
+++ b/src/spectrum/main.c
@@ -33,6 +33,7 @@ void main(void)
   cprintf("Enable graphics fill?(y/n)");
   while(1)
   {
+    in_Pause(1); // Slow this loop
     c = getch();
     if (c == 'y') {
       enable_fill = 1;

--- a/src/spectrum/main.c
+++ b/src/spectrum/main.c
@@ -66,7 +66,7 @@ void main(void)
       }
       */
       io_main();
-	    in_Pause(1);
+	    //in_Pause(1);
       keyboard_main();
     }
 }

--- a/src/spectrum/main.c
+++ b/src/spectrum/main.c
@@ -58,16 +58,22 @@ void main(void)
 #endif
 
   for (;;)
-    {  // CHANGE THE MAIN LOOP
-      /*
+    {  
+      /* CHANGES TO THE MAIN LOOP
+          We now only check the keyboard on NO RX data 
+          or while drawing on the screen, 
+          except during flood fills.
+      */
+      
+
+      #ifdef __UNO__  //Not tuned the UNO sorry...
       for(int Kscan=0;Kscan<20;Kscan++)  //Keyboard scanning loop		
       {
 	      keyboard_main();
       }
-      */
+      #endif
+      
       io_main();
-	    //in_Pause(1);
-      keyboard_main();
     }
 }
 

--- a/src/spectrum/main.c
+++ b/src/spectrum/main.c
@@ -57,7 +57,7 @@ void main(void)
 #endif
 
   for (;;)
-    {
+    {  // CHANGE THE MAIN LOOP
       /*
       for(int Kscan=0;Kscan<20;Kscan++)  //Keyboard scanning loop		
       {
@@ -65,6 +65,8 @@ void main(void)
       }
       */
       io_main();
+	    in_Pause(1);
+      keyboard_main();
     }
 }
 

--- a/src/spectrum/main.c
+++ b/src/spectrum/main.c
@@ -51,11 +51,19 @@ void main(void)
   connect();
 #endif
   io_init();
+
+#ifndef NO_BIT
   bit_play("2A--");  //Ready beep
-  
+#endif
+
   for (;;)
     {
-	    keyboard_main();
+      /*
+      for(int Kscan=0;Kscan<20;Kscan++)  //Keyboard scanning loop		
+      {
+	      keyboard_main();
+      }
+      */
       io_main();
     }
 }

--- a/src/spectrum/rs232/io.c
+++ b/src/spectrum/rs232/io.c
@@ -28,6 +28,7 @@ void io_init(void)
   help_prompt_input("Modem dial? y/n: ");
 
   rs232_params(RS_BAUD_9600|RS_STOP_1|RS_BITS_8,RS_PAR_NONE);  //  Bauds tested 1200[/] 2400[/] 4800[/] 9600[/] 19200[X] 38400[X] 57600[] 115200[] 
+  //rs232_params(RS_BAUD_19200|RS_STOP_1|RS_BITS_8,RS_PAR_NONE);  //  Bauds tested 1200[/] 2400[/] 4800[/] 9600[/] 19200[X] 38400[X] 57600[] 115200[] 
   rs232_init();
   io_initialized=1;
 
@@ -46,10 +47,20 @@ void io_init(void)
         }
       help_clear();
 
-      io_send_byte('a');
-      io_send_byte('t');
-      io_send_byte('d');
+      io_send_byte('A');
+      io_send_byte('T');
       io_send_byte(' ');
+
+      //Push CTS/RTS on
+      io_send_byte('&');
+      io_send_byte('K');
+      io_send_byte('3');
+      io_send_byte(' ');
+
+      io_send_byte('D');
+      io_send_byte('T');
+      io_send_byte(' ');
+
       int i=0;
       do
       {
@@ -86,10 +97,9 @@ void io_main(void)
     in_Pause(rxdelay);  // Hold off to get a buffer load
 
     // Mark screen while RX in progress
-	  gotoxy(0,0);
-    if(rxbufferlimit==rxbuffersize)		printf("X");  // BIG buffer active
-    else		                          printf("O");  // small buffer active
-
+//	  gotoxy(0,0);
+//    if(rxbufferlimit==rxbuffersize)		printf("X");  // BIG buffer active
+//    else		                          printf("O");  // small buffer active
 
     while (inb != RS_ERR_NO_DATA && bytes<rxbufferlimit)
     {// LOOP until no data or Buffer is FULL
@@ -107,7 +117,7 @@ void io_main(void)
     } 
 
     //  ADAPTIVE BUFFERING -- Try to not partially load pages, but if we blast the buffer in roses stream using a small buffer
-    if(inb != RS_ERR_NO_DATA || (bytes > 15 && bytes < 20))
+    if(inb != RS_ERR_NO_DATA || (bytes > 5 && bytes < 20))
     {//  Buffer flooded OR Buffer starved, switch to small buffer
       rxbufferlimit = 20;
     }
@@ -117,8 +127,7 @@ void io_main(void)
     }
     
     // Clear the RX data mark
-    gotoxy(0,0);
-    printf(" ");
+//    gotoxy(0,0);    printf(" ");
 
     
     ShowPLATO(rxdata,bytes);

--- a/src/spectrum/rs232/io.c
+++ b/src/spectrum/rs232/io.c
@@ -6,6 +6,8 @@
 #include "../../include/keyboard.h"
 #include "../../include/io.h"
 #include "../../include/protocol.h"
+#include "../../include/help.h"
+
 
 static unsigned char inb;
 char rxdata[2049];
@@ -14,9 +16,56 @@ char io_initialized=0;
 
 void io_init(void)
 {
-  rs232_params(RS_BAUD_9600|RS_STOP_1|RS_BITS_8,RS_PAR_NONE);  //  Bauds tested 1200[/] 2400[/] 4800[/] 9600[/] 19200[X] 38400[X] 57600[] 115200[] 
-  rs232_init();
-  io_initialized=1;
+
+  // PUT A CRAPPY MENU ON RS232 IO INIT
+  char host_name[80];
+  char c; 
+
+  help_prompt_input("Modem dial? y/n: ");
+  while(1)
+  {
+    in_Pause(1); // Slow this loop
+    c = getch();
+    if (c == 'y') 
+    {      
+      help_clear();
+      help_prompt_input("Enter Hostname or <ENTER> for IRATA.ONLINE: ");
+      cgets(host_name);
+      if (strcmp(host_name,"")==0)
+        {
+          strcpy(host_name,"IRATA.ONLINE:8005");
+        }
+      help_clear();
+
+
+      rs232_params(RS_BAUD_9600|RS_STOP_1|RS_BITS_8,RS_PAR_NONE);  //  Bauds tested 1200[/] 2400[/] 4800[/] 9600[/] 19200[X] 38400[X] 57600[] 115200[] 
+      rs232_init();
+      io_initialized=1;
+
+      io_send_byte('a');
+      io_send_byte('t');
+      io_send_byte('d');
+      io_send_byte(' ');
+      int i=0;
+      do
+      {
+        io_send_byte(host_name[i]);
+      } while (++i<strlen(host_name));
+      io_send_byte(0x0a);
+      break;
+    }
+    else if (c == 'n')  
+    {
+      help_clear();
+      rs232_params(RS_BAUD_9600|RS_STOP_1|RS_BITS_8,RS_PAR_NONE);  //  Bauds tested 1200[/] 2400[/] 4800[/] 9600[/] 19200[X] 38400[X] 57600[] 115200[] 
+      rs232_init();
+      io_initialized=1;
+      break;
+    }
+  }
+
+
+  
 }
 
 void io_send_byte(unsigned char b)

--- a/src/spectrum/rs232/io.c
+++ b/src/spectrum/rs232/io.c
@@ -34,10 +34,15 @@ void io_main(void)
     }
   else
     {  /* [NO RX - KEY scan] */  
+      in_Pause(10);
+      keyboard_main();
+
+    /*
       for(int Kscan=0;Kscan<30;Kscan++)  //Extra keyboard scanning					
-	{
-	  keyboard_main();
-	} 
+      {
+        keyboard_main();
+      } 
+    */
     }
 }
 #endif /* __SPECTRUM_RS232__ */

--- a/src/spectrum/rs232/io.c
+++ b/src/spectrum/rs232/io.c
@@ -8,7 +8,8 @@
 #include "../../include/protocol.h"
 
 static unsigned char inb;
-
+char rxdata[2049];
+static int bytes;
 char io_initialized=0;
 
 void io_init(void)
@@ -27,22 +28,34 @@ void io_send_byte(unsigned char b)
 }
 
 void io_main(void)
-{
+{  // NEW BUFFERED SERIAL CONNECTION (2048)
   if (rs232_get(&inb) != RS_ERR_NO_DATA)  	// *IRQ-OFF (RECEIVING DATA)
     {	/* [RX - Display] */ 	
-      ShowPLATO(&inb,1);
+
+    bytes = 0;
+    do
+    {
+      rxdata[bytes] = inb;
+      bytes++;
+    } while (rs232_get(&inb) != RS_ERR_NO_DATA & bytes<2048);
+    
+      ShowPLATO(rxdata,bytes);
+      //ShowPLATO(&inb,1);  // ORIGINAL
     }
   else
     {  /* [NO RX - KEY scan] */  
-      in_Pause(10);
-      keyboard_main();
+    
+    // CHANGE THE NO RX TIMING
 
-    /*
-      for(int Kscan=0;Kscan<30;Kscan++)  //Extra keyboard scanning					
+//    in_Pause(1);
+//    keyboard_main();
+  
+      for(int Kscan=0;Kscan<10;Kscan++)  //Extra keyboard scanning					
       {
+        in_Pause(1);
         keyboard_main();
       } 
-    */
+    
     }
 }
 #endif /* __SPECTRUM_RS232__ */

--- a/src/spectrum/screen.c
+++ b/src/spectrum/screen.c
@@ -118,7 +118,10 @@ void screen_char_draw(padPt* Coord, unsigned char* ch, unsigned char count)
   
   for (i=0;i<count;++i)
     {
-      keyboard_main();  // CHECK THE KEYBOARD HERE WHILE QUICK DRAWING
+      #ifdef __SPECTRUM__
+      keyboard_main();  // Spectrum additional keyboard checks when processing rxbuffer
+      #endif
+      
       a=*ch;
       ++ch;
       a+=offset;
@@ -177,7 +180,10 @@ void screen_char_draw(padPt* Coord, unsigned char* ch, unsigned char count)
   
   for (i=0;i<count;++i)
     {
-      keyboard_main();  // CHECK KEYBOARD HERE WHILE DRAWING
+      #ifdef __SPECTRUM__
+      keyboard_main();  // Spectrum additional keyboard checks when processing rxbuffer
+      #endif
+
       a=*ch;
       ++ch;
       a+=offset;

--- a/src/spectrum/screen.c
+++ b/src/spectrum/screen.c
@@ -118,6 +118,7 @@ void screen_char_draw(padPt* Coord, unsigned char* ch, unsigned char count)
   
   for (i=0;i<count;++i)
     {
+      keyboard_main();  // CHECK THE KEYBOARD HERE WHILE QUICK DRAWING
       a=*ch;
       ++ch;
       a+=offset;
@@ -176,6 +177,7 @@ void screen_char_draw(padPt* Coord, unsigned char* ch, unsigned char count)
   
   for (i=0;i<count;++i)
     {
+      keyboard_main();  // CHECK KEYBOARD HERE WHILE DRAWING
       a=*ch;
       ++ch;
       a+=offset;

--- a/src/spectrum/spectranet/io.c
+++ b/src/spectrum/spectranet/io.c
@@ -48,10 +48,7 @@ void io_main(void)
     }
   else
     {
-      for(int Kscan=0;Kscan<30;Kscan++)  //Extra keyboard scanning					
-	{
-	  keyboard_main();
-	} 
+	    keyboard_main();
     }
   
 }

--- a/src/spectrum/spectranet/io.c
+++ b/src/spectrum/spectranet/io.c
@@ -48,7 +48,14 @@ void io_main(void)
     }
   else
     {
-	    keyboard_main();
+      in_Pause(1);
+      keyboard_main();
+/*
+      for(int Kscan=0;Kscan<30;Kscan++)  //Extra keyboard scanning					
+      {
+        keyboard_main();
+      } 
+*/
     }
   
 }

--- a/src/spectrum/spectranet/io.c
+++ b/src/spectrum/spectranet/io.c
@@ -49,22 +49,17 @@ void io_main(void)
       // Clear the RX data mark
       //gotoxy(0,0);    printf(" ");
 
-      ShowPLATO(rxdata,bytes);
+      if(bytes!=0)  // Seems to stop some bugs with the network stopping
+        ShowPLATO(rxdata,bytes);
     }
   else
     {
-// TEST 0 *TOO Fast
-/*      
-      keyboard_main();
-*/
 
-// TEST 1  !Works
-
-      in_Pause(2);
+      in_Pause(10);  //This time drops to 0 on key push
       keyboard_main();
 
 
-//  TEST 2
+//  This is another way to do it and get more Keys sent before RX
 /*
       for(int Kscan=0;Kscan<10;Kscan++)  //Extra keyboard scanning					
       {// THIS IS THE MAIN KEYBOARD SCAN WINDOW NOW  
@@ -73,7 +68,7 @@ void io_main(void)
       } 
 */
 
-//  ORIGINAL
+//  ORIGINAL  -- Served us well but not required I have grown
 /*
       for(int Kscan=0;Kscan<30;Kscan++)  //Extra keyboard scanning					
       {

--- a/src/spectrum/spectranet/io.c
+++ b/src/spectrum/spectranet/io.c
@@ -62,7 +62,7 @@ void io_main(void)
 //  TEST 2
 
       for(int Kscan=0;Kscan<5;Kscan++)  //Extra keyboard scanning					
-      {
+      {// THIS IS THE MAIN KEYBOARD SCAN WINDOW NOW  
         in_Pause(1);
         keyboard_main();
       } 

--- a/src/spectrum/spectranet/io.c
+++ b/src/spectrum/spectranet/io.c
@@ -43,7 +43,12 @@ void io_main(void)
   pfd=poll_fd(sockfd);
   if (pfd & POLLIN)
     {
+      // RX data mark
+      //gotoxy(0,0);    printf("X");
       bytes=recv(sockfd,rxdata,2048,0);
+      // Clear the RX data mark
+      //gotoxy(0,0);    printf(" ");
+
       ShowPLATO(rxdata,bytes);
     }
   else
@@ -54,19 +59,19 @@ void io_main(void)
 */
 
 // TEST 1  !Works
-/*
+
       in_Pause(2);
       keyboard_main();
-*/
+
 
 //  TEST 2
-
-      for(int Kscan=0;Kscan<5;Kscan++)  //Extra keyboard scanning					
+/*
+      for(int Kscan=0;Kscan<10;Kscan++)  //Extra keyboard scanning					
       {// THIS IS THE MAIN KEYBOARD SCAN WINDOW NOW  
         in_Pause(1);
         keyboard_main();
       } 
-
+*/
 
 //  ORIGINAL
 /*

--- a/src/spectrum/spectranet/io.c
+++ b/src/spectrum/spectranet/io.c
@@ -48,20 +48,28 @@ void io_main(void)
     }
   else
     {
-/*  TEST 1
-      in_Pause(1);
+// TEST 0 *TOO Fast
+/*      
       keyboard_main();
 */
 
-//  BEST
-      for(int Kscan=0;Kscan<10;Kscan++)  //Extra keyboard scanning					
+// TEST 1  !Works
+/*
+      in_Pause(2);
+      keyboard_main();
+*/
+
+//  TEST 2
+
+      for(int Kscan=0;Kscan<5;Kscan++)  //Extra keyboard scanning					
       {
         in_Pause(1);
         keyboard_main();
       } 
 
 
-/* ORIGINAL
+//  ORIGINAL
+/*
       for(int Kscan=0;Kscan<30;Kscan++)  //Extra keyboard scanning					
       {
         keyboard_main();

--- a/src/spectrum/spectranet/io.c
+++ b/src/spectrum/spectranet/io.c
@@ -12,7 +12,7 @@
 
 static int sockfd, bytes, pfd;
 static struct sockaddr_in remoteaddr;
-char rxdata[1024];
+char rxdata[2049];
 struct hostent *he;
 char host_name[32];
 
@@ -43,14 +43,25 @@ void io_main(void)
   pfd=poll_fd(sockfd);
   if (pfd & POLLIN)
     {
-      bytes=recv(sockfd,rxdata,1,0);
-      ShowPLATO(rxdata,1);
+      bytes=recv(sockfd,rxdata,2048,0);
+      ShowPLATO(rxdata,bytes);
     }
   else
     {
+/*  TEST 1
       in_Pause(1);
       keyboard_main();
-/*
+*/
+
+//  BEST
+      for(int Kscan=0;Kscan<10;Kscan++)  //Extra keyboard scanning					
+      {
+        in_Pause(1);
+        keyboard_main();
+      } 
+
+
+/* ORIGINAL
       for(int Kscan=0;Kscan<30;Kscan++)  //Extra keyboard scanning					
       {
         keyboard_main();


### PR DESCRIPTION
Made changes to the RS232 and Spectranet versions.

Buffering is applied to the RS232 versions (IF1 PLUS), also tuned up the keyboard detection.  Using in_Pause to slow the code down between RX checks.  Hitting the keys brings the next RX check sooner as in_Pause counters 0 on keypress.

Spectranet is tuned up using in_Pause too.  I have commented out the for loop option, which wraps a smaller in_Pause.  Using one longer in_Pause works ok.  The for loop over a short pause lets you catch a few keys before next RX.  Doesn't seem to matter that much, assuming a good network connection the latency isn't bad.

The RS232 version now has a small Dialer menu on it.  I push the AT codes to set CTS/RTS then dial the hostname given (assuming HOST:PORT) string is correct with no checking!  Just hitting Enter dial irata.online which is 99% of the uses cases.

Sorry, there has been a shuffle on the indenting, needed the code collapse to work in the editor to see the loops.  It didn't like the style used :(

Added some Keyboard checks to some of the COMMONs, I have wrapped them in IFDEF __SPECTRUM__ to not break anything.  I know this is not the way forward, but I didn't want to take out the other versions with the update!

Made some changes to the Build scripts, we now have -O2 option set for improving performance.  It seems to work, but the boost is negligible considering some of the other changes!  Moved spectranet to SNET build folder, and added P3 which build the PLUS version but outputs a DSK file.  Super handy for putting on a USB and testing on a +3 with a GOTEK :)  There are a few minor changes to some of the commented outlines which are for ease of access like the TURBO DEV build options etc.

Hope this fixes more than it breaks!

Owen


