### PR TITLE
Alistair's Keyboard fix for TAP loaders

### DIFF
--- a/src/spectrum/main.c
+++ b/src/spectrum/main.c
@@ -21,6 +21,7 @@ unsigned char already_started=0;
 
 void main(void)
 {
+  bpoke(0x5C3B, bpeek(0x5C3B) | 0x8); /*Alistair's workaround to autoboot key mode issue */
   char c; 
   zx_border(INK_BLACK);  //Tidy up the borders on start up
   screen_init();


### PR DESCRIPTION
Should fix the keyboard not working when not loading Platoterm from BASIC.  (DIVMMC NMI or Spectranet BOOT.ZX files)
